### PR TITLE
Support for Android as bridge for Device Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ expects the rotational acceleration to be provided as input on
 ````
     msg.payload.d
 ````
-as
+as from an iOS bridge
 ````
     msg.payload.d.accelX
     msg.payload.d.accelY
     msg.payload.d.accelZ
+````
+or if from an Android bridge
+````
+    msg.payload.d.acc_x
+    msg.payload.d.acc_y
+    msg.payload.d.acc_z
 ````
 
 ### Calibration

--- a/nodes/v1.js
+++ b/nodes/v1.js
@@ -23,6 +23,11 @@ module.exports = function (RED) {
   function payloadCheck(msg) {
     var message = '';
     if (msg && msg.payload && msg.payload.d) {
+      // If data has come from an Android Bridge then
+      // the motion will be on acc_x, acc_y, accel_z
+      if (msg.payload.d.acc_x) {
+        androidSource(msg);
+      }
       if (! msg.payload.d.accelX ||
             ! msg.payload.d.accelY ||
             ! msg.payload.d.accelZ) {
@@ -32,6 +37,12 @@ module.exports = function (RED) {
       message = 'Missing device event';
     }
     return message;
+  }
+
+  function androidSource(msg) {
+    msg.payload.d.accelX = msg.payload.d.acc_x || 0;
+    msg.payload.d.accelY = msg.payload.d.acc_y || 0;
+    msg.payload.d.accelZ = msg.payload.d.acc_z || 0;
   }
 
   // Sensitivity is used to determine how much of a rotational

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sensor-rotation-to-phrase",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A node to interpret sensor rotation as phrases",
   "dependencies": {
   },


### PR DESCRIPTION
Device Events coming from an Android have a different signature to an iOS bridge.